### PR TITLE
refactor: Updated properties to use environment variables

### DIFF
--- a/seoulQuestBackend_1217/.env.template
+++ b/seoulQuestBackend_1217/.env.template
@@ -1,0 +1,5 @@
+export DB_HOST=
+export DB_PORT=
+export DB_SCHEMA=
+export DB_USER=
+export DB_PASSWORD=

--- a/seoulQuestBackend_1217/CONTRIBUTING.md
+++ b/seoulQuestBackend_1217/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+Note that if you're not using WSL on Windows, you should be. Also note that while IntelliJ is awesome, it's sometimes a little funky with WSL. You may need to do some configuration and plugin installation to get IntelliJ to work with WSL properly.
+
+## Setup
+
+1. Run `./gradlew` to get everything set up.
+2. Copy `.env.template` to `.env` (`cp .env.template .env`) and fill in the environment variable values in `.env`.
+
+## Running
+
+1. Run with `source && ./gradlew bootRun`.

--- a/seoulQuestBackend_1217/src/main/resources/application.properties
+++ b/seoulQuestBackend_1217/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 spring.application.name=seoulQuest
 
 
-spring.datasource.url=jdbc:mysql://localhost:3306/positivedb?serverTimezone=Asia/Seoul
-spring.datasource.username=positiveuser
-spring.datasource.password=
+spring.datasource.url=jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_SCHEMA:positivedb}?serverTimezone=Asia/Seoul
+spring.datasource.username=${DB_USER:positiveuser}
+spring.datasource.password=${DB_PASSWORD:1234}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update
@@ -32,8 +32,8 @@ spring.mail.properties.mail.smtp.timeout=5000
 spring.mail.properties.mail.smtp.writetimeout=5000
 
 #?? ??? admin email? ???? spring.mail.username=hyeny718@gmail.com? ???.
-admin.email=heatdaheat@naver.com
-admin.name=Seoulhwa Admin
+admin.email=${ADMIN_EMAIL:heatdaheat@naver.com}
+admin.name=${ADMIN_NAME:Seoulhwa Admin}
 
 iamport.api_key=
 iamport.api_secret=


### PR DESCRIPTION
According to the 12-Factor App design principles (https://12factor.net/), most configuration should be done via environment variables. Fortunately, Spring Boot's .properties files support environment variables natively.  I've updated application.properties to use environment variable string interpolation with default values. You should also apply this to the various username/password properties. I also added a .env.template file. A file like this is often used to explain to other engineers how to properly set environment variables. See the CONTRIBUTING.md for more info.