### PR TITLE
chore: Added docker-compose for easy local DB

### DIFF
--- a/seoulQuestBackend_1217/.env.template
+++ b/seoulQuestBackend_1217/.env.template
@@ -1,0 +1,5 @@
+export DB_HOST=
+export DB_PORT=
+export DB_SCHEMA=
+export DB_USER=
+export DB_PASSWORD=

--- a/seoulQuestBackend_1217/CONTRIBUTING.md
+++ b/seoulQuestBackend_1217/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+Note that if you're not using WSL on Windows, you should be. Also note that while IntelliJ is awesome, it's sometimes a little funky with WSL. You may need to do some configuration and plugin installation to get IntelliJ to work with WSL properly.
+
+## Setup
+
+1. Run `./gradlew` to get everything set up.
+2. Copy `.env.template` to `.env` (`cp .env.template .env`) and fill in the environment variable values in `.env`.
+
+## Running
+
+1. Run with `source && ./gradlew bootRun`.

--- a/seoulQuestBackend_1217/CONTRIBUTING.md
+++ b/seoulQuestBackend_1217/CONTRIBUTING.md
@@ -9,4 +9,13 @@ Note that if you're not using WSL on Windows, you should be. Also note that whil
 
 ## Running
 
-1. Run with `source && ./gradlew bootRun`.
+Make sure you have Docker Desktop or Rancher Desktop installed. Note that Docker Desktop requires payment if your organization has more than some number of people, but it is free to use for personal or very small projects. Rancher Desktop has no such requirements.
+
+1. Run `docker compose up -d` to run a local database and a local database UI at [http://localhost:8000](http://localhost:8000).
+2. Run with `source && ./gradlew bootRun`.
+
+## Teardown
+
+1. Run `docker compose down` to stop and remove all the local development Docker containers.
+
+Note that the database contents will be persisted because they're in a volume. If you want to completely clean out the database contents, you'll need to delete the Docker volume. See Docker CLI help on how to do this.

--- a/seoulQuestBackend_1217/MySql/data.sql
+++ b/seoulQuestBackend_1217/MySql/data.sql
@@ -1,5 +1,0 @@
-create database positivedb;
-use positivedb;
-
-create user`positiveuser`@`%` identified by '1234'; 
-grant all privileges on positivedb.* to `positiveuser`@`%`;

--- a/seoulQuestBackend_1217/docker-compose.yaml
+++ b/seoulQuestBackend_1217/docker-compose.yaml
@@ -1,0 +1,39 @@
+services:
+  db:
+    image: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: positivedb
+      MYSQL_USER: positiveuser
+      MYSQL_PASSWORD: 1234
+    networks:
+      - seoulhwa-backend_default
+    ports:
+      - published: 3306
+        target: 3306
+    volumes:
+      - type: volume
+        source: db_data_volume
+        target: /var/lib/mysql
+
+  db_ui:
+    image: ghcr.io/shyim/adminerevo:latest
+    ports:
+      - published: 8000
+        target: 8080
+    environment:
+      ADMINER_DEFAULT_DRIVER: server
+      ADMINER_DEFAULT_SERVER: db
+      ADMINER_DEFAULT_USER: positivedb
+      ADMINER_DEFAULT_PASSWORD: 1234
+      ADMINER_DEFAULT_DB: positivedb
+    networks:
+      - seoulhwa-backend_default
+
+volumes:
+  db_data_volume: {}
+
+networks:
+  seoulhwa-backend_default:
+    driver: bridge
+    name: seoulhwa-backend_default

--- a/seoulQuestBackend_1217/src/main/resources/application.properties
+++ b/seoulQuestBackend_1217/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 spring.application.name=seoulQuest
 
 
-spring.datasource.url=jdbc:mysql://localhost:3306/positivedb?serverTimezone=Asia/Seoul
-spring.datasource.username=positiveuser
-spring.datasource.password=
+spring.datasource.url=jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_SCHEMA:positivedb}?serverTimezone=Asia/Seoul
+spring.datasource.username=${DB_USER:positiveuser}
+spring.datasource.password=${DB_PASSWORD:1234}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update
@@ -32,8 +32,8 @@ spring.mail.properties.mail.smtp.timeout=5000
 spring.mail.properties.mail.smtp.writetimeout=5000
 
 #?? ??? admin email? ???? spring.mail.username=hyeny718@gmail.com? ???.
-admin.email=heatdaheat@naver.com
-admin.name=Seoulhwa Admin
+admin.email=${ADMIN_EMAIL:heatdaheat@naver.com}
+admin.name=${ADMIN_NAME:Seoulhwa Admin}
 
 iamport.api_key=
 iamport.api_secret=


### PR DESCRIPTION
Docker Compose is very helpful for running services locally and avoiding the need to install every version of every database just to do backend development. Using just one command, we can bring up a database and a UI to browse that database. We can also use just one command to clean it all up. See CONTRIBUTING.md for details.

NOTE THAT THIS SHOULD BE MERGED AFTER THE CONFIGURATION IMPROVEMENTS PR.